### PR TITLE
Fix compilation with kwin 5.26

### DIFF
--- a/src/Shaders.cpp
+++ b/src/Shaders.cpp
@@ -86,7 +86,6 @@ ShadersEffect::ShadersEffect() : m_shader(nullptr), m_effectEnabled(false) {
  */
 ShadersEffect::~ShadersEffect() {
     delete m_settings;
-    delete m_shader;
     delete m_server;
 }
 
@@ -301,11 +300,11 @@ void ShadersEffect::paintWindow(EffectWindow* w, int mask, const QRegion region,
         effects->paintWindow(w, mask, region, data);
         return;
     }
-    ShaderBinder bind(m_shader);
+    ShaderBinder bind(m_shader.get());
     m_shader->setUniform("g_Random", (float) drand48());
     m_shader->setUniform("g_TextureSize", QVector2D(effects->virtualScreenSize().width(), effects->virtualScreenSize().height()));
     m_shader->setUniform("modelViewProjectionMatrix", data.projectionMatrix());
-    data.shader = m_shader;
+    data.shader = m_shader.get();
     effects->paintWindow(w, mask, region, data);
 }
 

--- a/src/Shaders.cpp
+++ b/src/Shaders.cpp
@@ -300,11 +300,19 @@ void ShadersEffect::paintWindow(EffectWindow* w, int mask, const QRegion region,
         effects->paintWindow(w, mask, region, data);
         return;
     }
+#if KWIN_EFFECT_API_VERSION >= 234
     ShaderBinder bind(m_shader.get());
+#else
+    ShaderBinder bind(m_shader);
+#endif
     m_shader->setUniform("g_Random", (float) drand48());
     m_shader->setUniform("g_TextureSize", QVector2D(effects->virtualScreenSize().width(), effects->virtualScreenSize().height()));
     m_shader->setUniform("modelViewProjectionMatrix", data.projectionMatrix());
+#if KWIN_EFFECT_API_VERSION >= 234
     data.shader = m_shader.get();
+#else
+    data.shader = m_shader;
+#endif
     effects->paintWindow(w, mask, region, data);
 }
 

--- a/src/Shaders.h
+++ b/src/Shaders.h
@@ -42,7 +42,11 @@ public:
     static bool supported();
 
 private:
+#if KWIN_EFFECT_API_VERSION >= 234
     std::unique_ptr<GLShader> m_shader;
+#else
+    GLShader *m_shader;
+#endif
     QLocalServer *m_server;
     QSettings *m_settings;
     bool m_effectEnabled;

--- a/src/Shaders.h
+++ b/src/Shaders.h
@@ -42,7 +42,7 @@ public:
     static bool supported();
 
 private:
-    GLShader *m_shader;
+    std::unique_ptr<GLShader> m_shader;
     QLocalServer *m_server;
     QSettings *m_settings;
     bool m_effectEnabled;


### PR DESCRIPTION
On 5.26 `ShaderManager::generateCustomShader` return a `unique_ptr` instead of raw pointer